### PR TITLE
(fix) Add babel-loader to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "axios": "^0.16.0",
     "babel-cli": "^6.24.1",
+    "babel-loader": "^6.4.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",


### PR DESCRIPTION
package.json was missing babel-loader in dependencies. Required for Heroku deployment, once again please open a pull request to merge dev into master once this has been merged into dev.